### PR TITLE
Update Makefile to detect gcc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ TST-LIBS          = $(addprefix test_lib/,lib1.so SimpleMul.so SimpleIni.so Simp
 
 # TODO: check gcc version to conditionally disable fcf
 # early version could complain about this flag
-CFLAGS = -g -shared -fPIC -fcf-protection=none
+CFLAGS = -g -shared -fPIC
+GCCVERSIONGTEQ9 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 9)
+ifeq "$(GCCVERSIONGTEQ9)" "1"
+	CFLAGS += -fcf-protection=none
+endif
 LDFLAGS = -ldl
 CUSTOM-LDR = -L./build -Wl,-rpath,./build -l:loader-sample.so
 REAL-LDR = -L./build -Wl,-rpath,./build -l:loader.so

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ LOADER-SAMPLE-SRC = $(addprefix src/orig/,OpenLibrary.c MapLibrary.c RelocLibrar
 						FindSymbol.c RuntimeResolve.c trampoline.S InitLibrary.c)
 TST-LIBS          = $(addprefix test_lib/,lib1.so SimpleMul.so SimpleIni.so SimpleData.so)
 
-# TODO: check gcc version to conditionally disable fcf
-# early version could complain about this flag
+# https://wiki.ubuntu.com/ToolChain/CompilerFlags
+# Thanks to Ubuntu Wiki, I know that control flow protection was introduced since 19.04
+# But I can't tell the accurate gcc version for it is even OS-dependent
+# At the end of day I decide to keep things broken and enable it only on 20.04  
 CFLAGS = -g -shared -fPIC
 GCCVERSIONGTEQ9 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 9)
 ifeq "$(GCCVERSIONGTEQ9)" "1"


### PR DESCRIPTION
Fix the issue that gcc won't recognize `-fcf-protection` option, tested on Ubuntu 16.04, 18.04, 20.04.