### PR TITLE
Issue8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 src/orig
 legacy
+feature-test/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# DO NOT MODIFY
+
 CC = gcc
 LOADER-SRC        = $(addprefix src/,OpenLibrary.c MapLibrary.c RelocLibrary.c \
 						FindSymbol.c RuntimeResolve.c trampoline.S InitLibrary.c)
@@ -6,6 +8,10 @@ LOADER-SAMPLE-SRC = $(addprefix src/orig/,OpenLibrary.c MapLibrary.c RelocLibrar
 TST-LIBS          = $(addprefix test_lib/,lib1.so SimpleMul.so SimpleIni.so SimpleData.so)
 
 USE-CUSTOM-LDR ?= F
+
+LOADER-SRC += util/shim.c
+
+LOADER-SAMPLE-SRC += util/shim.c
 
 # https://wiki.ubuntu.com/ToolChain/CompilerFlags
 # Thanks to Ubuntu Wiki, I know that control flow protection was introduced since 19.04
@@ -79,3 +85,6 @@ build/run-openlib: test.c
 
 clean:
 	rm -f build/loader.so build/loader-sample.so build/run-dlopen build/run-openlib
+
+cleanlib:
+	rm -f test_lib/*.so

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ LDFLAGS = -ldl
 LDR = -L./build -Wl,-rpath,./build
 ifeq "$(USE-CUSTOM-LDR)" "F"
 	LDR += -l:loader.so
-	ALL-OBJ = loader libs test shim
+	ALL-OBJ = loader libs test
 else
 	LDR += -l:loader-sample.so
-	ALL-OBJ = loader-sample libs test shim
+	ALL-OBJ = loader-sample libs test
 endif
 
 all: $(ALL-OBJ)
@@ -72,10 +72,10 @@ build/run-openlib: test.c
 	$(CC) -g -o $@ $< $(LDR)
 
 # shim layer that is used to intercept calls to critical functions
-shim: build/libshim.so 
+# shim: build/libshim.so 
 
-build/libshim.so: util/shim.c 
-	$(CC) $(CFLAGS) -o $@ $< $(LDR) $(LDFLAGS) -lshim-dep
+# build/libshim.so: util/shim.c 
+# 	$(CC) $(CFLAGS) -o $@ $< $(LDR) $(LDFLAGS)
 
 clean:
 	rm -f build/loader.so build/loader-sample.so build/run-dlopen build/run-openlib

--- a/autograder.py
+++ b/autograder.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+from curses import noecho
 import subprocess
 import signal
 import sys
@@ -8,6 +9,38 @@ VOID_VOID = '0'
 INT_INTINT = '1'
 
 INT_INTINT_L = 1 << 4
+
+class FuncUsage:
+
+    def __init__(self, funcList) -> None:
+        self.funcList = funcList
+
+    def compare(self, log):
+        # print("***printing from func_usage class!")
+        # print(log)
+        stderrLine = log.split('\n')
+        violate = 0
+        for line in stderrLine:
+            if len(line.split(':')) != 2:
+                # ignore if the line does not conform to <funcName>: <usage>
+                continue
+            funcName = line.split(":")[0]
+            usage    = line.split(":")[1]
+            usageNum = int(usage)
+            if usageNum == 0:
+                continue
+            if funcName in self.funcList:
+                if self.funcList[funcName] != usageNum:
+                    print("Function name:", funcName, "Expected usage:", self.funcList[funcName], "Real usage:", usageNum)
+                    violate += 1
+            else:
+                # find a function that is not inside the function list
+                print("Function name:", funcName, "Expected usage: 0, Real usage:", usageNum)
+                violate += 1
+        if violate == 0:
+            return True
+        else:
+            return False
 
 class TestCase:
 
@@ -22,6 +55,18 @@ class TestCase:
         self.extraArg = len(args)
         self.args = args
         self.craftAns = 0
+        self.funcWrapper = None
+
+    def check_usage(self, log):
+        if self.funcWrapper is not None:
+            ret = self.funcWrapper.compare(log)
+            return ret
+        else:
+            # no function wrapper, we don't check it 
+            return True
+    
+    def add_wrapper(self, wrapList):
+        self.funcWrapper = FuncUsage(wrapList)
 
     def assign_score(self, score):
         self.score = score
@@ -97,10 +142,15 @@ class TestCase:
                 else:
                     realAns = DLProc.stdout
                 if RetProc.stdout == realAns:
-                    self.claimedScore += self.score
-                    print("Expected output:", realAns)
-                    print("Your output:", RetProc.stdout)
-                    print("Passed!")
+                    if self.check_usage(RetProc.stderr) == False:
+                        # handle usage comparation in FuncUsage class
+                        print("Correct output while abusing system functions.\nYou are free to test your implementation in this way, but no score for you.")
+                        print("Shim checking failed!")
+                    else:
+                        self.claimedScore += self.score
+                        print("Expected output:", realAns)
+                        print("Your output:", RetProc.stdout)
+                        print("Passed!")
                 else:
                     print("TestCase failed.")
                     print("Expected output:", realAns)
@@ -126,26 +176,32 @@ if __name__ == '__main__':
     test0 = TestCase('SimpleMul', 'multiply', INT_INTINT, '2', '3')
     test0.assign_score(80)
     test0.assign_name('zero relocation')
+    test0.add_wrapper(dict())
     allTests.append(test0)
     test1 = TestCase('lib1', 'foo', VOID_VOID)
     test1.assign_score(5)
     test1.assign_name('fake libc(one PLT relocation with answer known)')
+    test1.add_wrapper({"dlopen": 1, "dlsym": 2})
     allTests.append(test1)
     test2 = TestCase('SimpleIni', 'entry', VOID_VOID)
     test2.assign_score(5)
+    test2.add_wrapper({"dlopen": 1, "dlsym": 2})
     test2.assign_name('one initialization(depend on test 1)')
     allTests.append(test2)
     test3 = TestCase('SimpleDep', 'wrapper', INT_INTINT, '2', '3')
     test3.assign_score(3)
     test3.assign_name('one true PLT relocation')
+    test3.add_wrapper(dict())
     allTests.append(test3)
     test4 = TestCase('SimpleData', 'wrapper', VOID_VOID)
     test4.assign_score(3)
     test4.assign_name('one global data relocation')
+    test4.add_wrapper({"dlopen": 1, "dlsym": 2})
     allTests.append(test4)
     test5 = TestCase('IndirectDep', 'wrapperAgain', INT_INTINT, '2', '3')
     test5.assign_score(2)
     test5.assign_name('one 2-layer relocation')
+    test5.add_wrapper(dict())
     allTests.append(test5)
     # TODO: check whether the second call still calls trampoline
     # requires a distinct function type
@@ -153,6 +209,7 @@ if __name__ == '__main__':
     test6.assign_score(2)
     test6.assign_name('lazy binding')
     test6.add_answer(b'Resolving address for entry 0\n6\n')
+    test6.add_wrapper({"printf": 1})
     allTests.append(test6)
     # sanity tests end
     """

--- a/autograder.py
+++ b/autograder.py
@@ -109,6 +109,10 @@ class TestCase:
         except subprocess.CalledProcessError as e:
             if e.returncode == -signal.SIGSEGV:
                 print("SIGSEGV received in custom loader. Maybe you want to debug it with gdb.")
+            elif e.returncode == -signal.SIGABRT:
+                print("SIGABRT received in custom loader. Exit as expected.")
+                print("Last words from stdout:", e.stdout)
+                print("Last words from stderr:", e.stderr)
             else:
                 print("Oops, custom loader does not return normally.")
                 print("Last words from stdout:", e.stdout)

--- a/src/Link.h
+++ b/src/Link.h
@@ -11,9 +11,13 @@
 #include <stdint.h>
 #include <elf.h>
 
+#include "../util/shim.h"
+
 #define OS_SPECIFIC_FLAG 2
 #define DT_RELACOUNT_NEW (DT_NUM)
 #define DT_GNU_HASH_NEW (DT_NUM + 1)
+
+/* DO NOT MODIFY ANYTHING ABOVE */
 
 typedef struct linkMap
 {

--- a/src/RelocLibrary.c
+++ b/src/RelocLibrary.c
@@ -27,7 +27,7 @@ void *symbolLookup(LinkMap *dep, const char *name)
         if(!handle)
         {
             fprintf(stderr, "relocLibrary error: cannot dlopen a fake object named %s", dep->name);
-            exit(-1);
+            abort();
         }
         dep->fakeHandle = handle;
         return dlsym(handle, name);

--- a/test.c
+++ b/test.c
@@ -35,7 +35,10 @@ int main(int argc, char *argv[], char *env[])
 #else
         fprintf(stderr, "OpenLibrary cannot open file: %s\n", argv[1]);
 #endif
-        exit(-1);
+        // switch from exit to abort, indicating that this is an unwanted (but expected) exit
+        // in this way destructor functions will not be called
+        // exit(-1);
+        abort();
     }
 
     int func_type = atoi(argv[3]);
@@ -59,7 +62,8 @@ int main(int argc, char *argv[], char *env[])
 #else
                 fprintf(stderr, "FindSymbol cannot find symbol: %s\n", argv[2]);
 #endif
-                exit(-1);
+                // exit(-1);
+                abort();
             }
             f();
             break;
@@ -79,7 +83,8 @@ int main(int argc, char *argv[], char *env[])
 #else
                 fprintf(stderr, "FindSymbol cannot find symbol: %s\n", argv[2]);
 #endif
-                exit(-1);
+                // exit(-1);
+                abort();
             }
             int op1 = atoi(argv[4]);
             int op2 = atoi(argv[5]);

--- a/util/shim.c
+++ b/util/shim.c
@@ -1,49 +1,94 @@
-/* Helper library. DO NOT MODIFY */
-#define __GNU_SOURCE
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <dlfcn.h>
 #include <stdarg.h>
+#include <string.h>
 
-#include "shim.h"
+/* notify the header to not replace out implementation */
+#define IN_SHIM
 
-static void *libc_handle;
 static int printf_usage;
+static int fprintf_usage;
 
-/* A note that is not related to this project:
-   The aim of shim library is to prevent the easy usage of printf and dl-family functions
-   such that students can easily bypass the certain tests, which is not the best thing for me to see.
-   During debugging, fprintf is used to see if it is working expectedly,
-   but after I finish all shim functions, fprintf will also be interposed and thus failing the tests. */
-
-__attribute__((constructor))
-static void shim_private_init()
+int myprintf(const char *__restrict__ __format, ...)
 {
-    // fprintf(stdout, "initializing shim library\n");
-    // libc_handle = dlopen("libc.so.6", RTLD_LAZY);
-    // if (!libc_handle) {
-    //     fprintf(stderr, "load shim library failed because: %s\n", dlerror());
-    //     exit(-1);
-    // }
-}
+    va_list arg;
+    va_start(arg, __format);
+    vprintf(__format, arg);
 
-int printf(const char *__restrict__ __format, ...)
-{   
-    va_list args;
-    va_start(args, __format);
-
-    int (*real_printf)(const char *__restrict__, va_list) = dlsym(RTLD_NEXT, "vprintf");
-    if (!real_printf) {
-        fprintf(stderr, "shim library cannot find the address of printf\n");
-        exit(-1);
-    }
-
-    real_printf(__format, args);
-    fprintf(stdout, "current printf usage: %d\n", printf_usage);
+    // printf("intercepted\n");
     printf_usage++;
 }
 
-// void *dlopen(const char *name, int mode)
-// {
-//     void (*real_dlopen)(const char *, int) = dlsym(libc_handle, "dlopen");
-// }
+int myfprintf(FILE *__restrict__ __stream, const char *__restrict__ __format, ...)
+{
+    va_list arg;
+    va_start(arg, __format);
+    vfprintf(__stream, __format, arg);
+
+    // printf("intercepted\n");
+    fprintf_usage++;
+}
+
+/* C macro will always parse comma into argument separator,
+   in which case, the previous expanded tokens can never included comma.
+   In other words, we cannot expect a token that contains comma, e.g. "hello,world"
+   which would always be interpreted as two tokens in preprocessor.
+   That is to say, I cannot find a way to generate comma separated argument list using
+   multiple layers of nested macros, as shown below.
+   If the level of indirect call level calls ever reach 2, the macro will not correctly parse
+   the number of arguments.
+   
+   The idea behind such failed attempt, however, is pretty useful though.
+   One can use __VA_ARGS__ counter to jump to an macro entry, and get expanded all the way to the bottom.
+   For example, if MERGE_TOKEN is called with 6 arguments, the expected behavior should be that
+   first performing incremental task, then extracting __VA_ARGS__, and finally call JOIN_TOKEN4.
+   This is the C macro way of traversing variable length macro.  */
+
+// #define FUNCTION_MACRO(func, ret, type1, arg1, type2, arg2, type3, arg3, type4, arg4)
+#define VARCOUNT_I(_, _10, _9, _8, _7, _6, _5, _4, _3, _2, X, ...) X
+#define VARCOUNT(...) VARCOUNT_I(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1) 
+#define CAT1(x, y) x##y
+#define CAT(x, y) CAT1(x, y)
+// #define JOIN_TOKEN(_, a, b, ...) _, a b
+// #define JOIN_TOKEN(...) __VA_ARGS__
+// #define JOIN_TOKEN2(_, a, b, ...) JOIN_TOKEN(_ a b COMMA, __VA_ARGS__)
+#define JOIN_TOKEN2(a, b) a b
+#define SELECT_TOKEN2(a, b) b
+#define JOIN_TOKEN4(a, b, c, d) JOIN_TOKEN2(a, b) , JOIN_TOKEN2(c, d)
+#define SELECT_TOKEN4(a, b, c, d) SELECT_TOKEN2(a, b) , SELECT_TOKEN2(c, d)
+#define JOIN_TOKEN6(a, b, c, d, e, f) JOIN_TOKEN4(a, b, c, d) , JOIN_TOKEN2(e, f)
+#define SELECT_TOKEN6(a, b, c, d, e, f) SELECT_TOKEN4(a, b, c, d) , SELECT_TOKEN2(e, f)
+#define JOIN_TOKEN8(a, b, c, d, e, f, g, h) JOIN_TOKEN4(a, b, c, d) , JOIN_TOKEN4(e, f, g, h)
+#define SELECT_TOKEN8(a, b, c, d, e, f, g, h) SELECT_TOKEN4(a, b, c, d) , SELECT_TOKEN4(e, f, g, h)
+#define JOIN_TOKEN10(a, b, c, d, e, f, g, h, i, j) JOIN_TOKEN8(a, b, c, d, e, f, g, h) , JOIN_TOKEN2(i, j)
+#define SELECT_TOKEN10(a, b, c, d, e, f, g, h, i, j) SELECT_TOKEN8(a, b, c, d, e, f, g, h) , SELECT_TOKEN2(i, j)
+#define MERGE_TOKEN(...) CAT(JOIN_TOKEN, VARCOUNT(__VA_ARGS__)) (__VA_ARGS__)
+#define KEEP_NAME(...) CAT(SELECT_TOKEN, VARCOUNT(__VA_ARGS__)) (__VA_ARGS__)
+
+#define FUNCTION_MACRO(func, ret, ...) \
+static int func##_usage; \
+ret my##func(MERGE_TOKEN(__VA_ARGS__)) \
+{ \
+    func(KEEP_NAME(__VA_ARGS__)); \
+    func##_usage++; \
+}
+
+#define PRINT_FUNC_USAGE(func) \
+printf(#func ": %d\n", func##_usage);
+
+FUNCTION_MACRO(dlopen, void *, const char *, name, int, mode);
+FUNCTION_MACRO(dlsym, void *, void *, handle, const char *, name);
+FUNCTION_MACRO(fwrite, size_t, const void *, ptr, size_t, size, size_t, nmemb, FILE *, stream);
+
+__attribute__((destructor))
+void shim_summary()
+{
+    printf("program exits, retrieving shim statistics\n");
+    PRINT_FUNC_USAGE(printf);
+    PRINT_FUNC_USAGE(fprintf);
+    PRINT_FUNC_USAGE(dlopen);
+    PRINT_FUNC_USAGE(dlsym);
+    PRINT_FUNC_USAGE(fwrite);
+}

--- a/util/shim.c
+++ b/util/shim.c
@@ -71,21 +71,32 @@ int myfprintf(FILE *__restrict__ __stream, const char *__restrict__ __format, ..
 static int func##_usage; \
 ret my##func(MERGE_TOKEN(__VA_ARGS__)) \
 { \
-    func(KEEP_NAME(__VA_ARGS__)); \
+    ret retval = func(KEEP_NAME(__VA_ARGS__)); \
     func##_usage++; \
+    return retval; \
 }
 
 #define PRINT_FUNC_USAGE(func) \
-printf(#func ": %d\n", func##_usage);
+fprintf(stderr, #func ": %d\n", func##_usage)
 
 FUNCTION_MACRO(dlopen, void *, const char *, name, int, mode);
-FUNCTION_MACRO(dlsym, void *, void *, handle, const char *, name);
+// FUNCTION_MACRO(dlsym, void *, void *, handle, const char *, name);
 FUNCTION_MACRO(fwrite, size_t, const void *, ptr, size_t, size, size_t, nmemb, FILE *, stream);
+
+// escape dlsym because I don't want the failed searches to generate an unreadable result
+static int dlsym_usage;
+void *mydlsym(void *__restrict __handle, const char *__restrict __name)
+{
+    void *sym = dlsym(__handle, __name);
+    if (sym)    
+        dlsym_usage++;
+    return sym;
+}
 
 __attribute__((destructor))
 void shim_summary()
 {
-    printf("program exits, retrieving shim statistics\n");
+    // printf("program exits, retrieving shim statistics\n");
     PRINT_FUNC_USAGE(printf);
     PRINT_FUNC_USAGE(fprintf);
     PRINT_FUNC_USAGE(dlopen);

--- a/util/shim.c
+++ b/util/shim.c
@@ -1,0 +1,49 @@
+/* Helper library. DO NOT MODIFY */
+#define __GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <stdarg.h>
+
+#include "shim.h"
+
+static void *libc_handle;
+static int printf_usage;
+
+/* A note that is not related to this project:
+   The aim of shim library is to prevent the easy usage of printf and dl-family functions
+   such that students can easily bypass the certain tests, which is not the best thing for me to see.
+   During debugging, fprintf is used to see if it is working expectedly,
+   but after I finish all shim functions, fprintf will also be interposed and thus failing the tests. */
+
+__attribute__((constructor))
+static void shim_private_init()
+{
+    // fprintf(stdout, "initializing shim library\n");
+    // libc_handle = dlopen("libc.so.6", RTLD_LAZY);
+    // if (!libc_handle) {
+    //     fprintf(stderr, "load shim library failed because: %s\n", dlerror());
+    //     exit(-1);
+    // }
+}
+
+int printf(const char *__restrict__ __format, ...)
+{   
+    va_list args;
+    va_start(args, __format);
+
+    int (*real_printf)(const char *__restrict__, va_list) = dlsym(RTLD_NEXT, "vprintf");
+    if (!real_printf) {
+        fprintf(stderr, "shim library cannot find the address of printf\n");
+        exit(-1);
+    }
+
+    real_printf(__format, args);
+    fprintf(stdout, "current printf usage: %d\n", printf_usage);
+    printf_usage++;
+}
+
+// void *dlopen(const char *name, int mode)
+// {
+//     void (*real_dlopen)(const char *, int) = dlsym(libc_handle, "dlopen");
+// }

--- a/util/shim.h
+++ b/util/shim.h
@@ -1,0 +1,22 @@
+#ifndef ELFLOADER_SHIM
+#define ELFLOADER_SHIM
+
+#include <stdlib.h>
+#ifndef IN_SHIM
+
+/* suppress warnings */
+extern int myprintf(const char *__restrict__ __format, ...);
+extern int myfprintf(FILE *__restrict__ __stream, const char *__restrict__ __format, ...);
+extern void *mydlopen (const char *__file, int __mode);
+extern void *mydlsym (void *__restrict __handle, const char *__restrict __name);
+extern size_t myfwrite (const void *__restrict __ptr, size_t __size, size_t __n, FILE *__restrict __s);
+
+#define printf(format, ...) myprintf(format, ##__VA_ARGS__)
+#define fprintf(stream, format, ...) myfprintf(stream, format, ##__VA_ARGS__)
+#define dlopen(file, mode) mydlopen(file, mode)
+#define dlsym(h, n) mydlsym(h, n)
+#define fwrite(p, sz, n, s) myfwrite(p, sz, n, s)
+
+#endif
+
+#endif


### PR DESCRIPTION
#8 requires the detection of glibc functions, which could be used to subvert the monitoring of autograder.

This branch introduce a shim library and compile-time interposing, so that calls to critical functions would be replaced by the preprocessor, with increments to corresponding counters.
Later the autograder checks the shim output and decides whether the code has violated the limitation.